### PR TITLE
解决实例级熔断没有传入sourceservice的问题 (#308)

### DIFF
--- a/polaris-common/polaris-client/src/main/java/com/tencent/polaris/client/flow/BaseFlow.java
+++ b/polaris-common/polaris-client/src/main/java/com/tencent/polaris/client/flow/BaseFlow.java
@@ -19,6 +19,7 @@ package com.tencent.polaris.client.flow;
 
 import com.tencent.polaris.api.config.Configuration;
 import com.tencent.polaris.api.config.global.APIConfig;
+import com.tencent.polaris.api.config.provider.ServiceConfig;
 import com.tencent.polaris.api.exception.ErrorCode;
 import com.tencent.polaris.api.exception.PolarisException;
 import com.tencent.polaris.api.exception.RetriableException;
@@ -96,8 +97,9 @@ public class BaseFlow {
         Map<String, String> metadata = new HashMap<>();
         metadata.put("protocol", protocol);
         dstSvcInfo.setMetadata(metadata);
+        ServiceConfig serviceConfig = extensions.getConfiguration().getProvider().getService();
         RouteInfo routeInfo = new RouteInfo(
-                null, null, dstSvcInfo, null, "");
+                null, null, dstSvcInfo, null, "", serviceConfig);
         ResourcesResponse resourcesResponse = BaseFlow
                 .syncGetResources(extensions, false, provider, flowControlParam);
         LOG.debug("[ConnectionManager]success to discover service {}", svcEventKey);

--- a/polaris-common/polaris-model/src/main/java/com/tencent/polaris/api/pojo/ServiceInfo.java
+++ b/polaris-common/polaris-model/src/main/java/com/tencent/polaris/api/pojo/ServiceInfo.java
@@ -27,9 +27,7 @@ import java.util.Map;
  */
 public class ServiceInfo implements ServiceMetadata, Comparable<ServiceInfo> {
 
-    private String namespace;
-
-    private String service;
+    private final ServiceKey serviceKey = new ServiceKey();
 
     private Map<String, String> metadata;
 
@@ -37,20 +35,20 @@ public class ServiceInfo implements ServiceMetadata, Comparable<ServiceInfo> {
 
     @Override
     public String getNamespace() {
-        return namespace;
+        return serviceKey.getNamespace();
     }
 
     public void setNamespace(String namespace) {
-        this.namespace = namespace;
+        serviceKey.setNamespace(namespace);
     }
 
     @Override
     public String getService() {
-        return service;
+        return serviceKey.getService();
     }
 
     public void setService(String service) {
-        this.service = service;
+        serviceKey.setService(service);
     }
 
     public String getRevision() {
@@ -70,12 +68,16 @@ public class ServiceInfo implements ServiceMetadata, Comparable<ServiceInfo> {
         this.metadata = metadata;
     }
 
+    public ServiceKey getServiceKey() {
+        return serviceKey;
+    }
+
     @Override
     @SuppressWarnings("checkstyle:all")
     public String toString() {
         return "ServiceInfo{" +
-                "namespace='" + namespace + '\'' +
-                ", service='" + service + '\'' +
+                "namespace='" + serviceKey.getNamespace() + '\'' +
+                ", service='" + serviceKey.getService() + '\'' +
                 ", metadata=" + metadata +
                 '}';
     }
@@ -86,8 +88,8 @@ public class ServiceInfo implements ServiceMetadata, Comparable<ServiceInfo> {
 
     @Override
     public int compareTo(ServiceInfo o) {
-        String key1 = namespace + "##" + service;
-        String key2 = o.namespace + "##" + o.service;
+        String key1 = serviceKey.getNamespace() + "##" + serviceKey.getService();
+        String key2 = o.getNamespace() + "##" + o.getService();
         return key1.compareTo(key2);
     }
 

--- a/polaris-common/polaris-model/src/main/java/com/tencent/polaris/api/pojo/ServiceKey.java
+++ b/polaris-common/polaris-model/src/main/java/com/tencent/polaris/api/pojo/ServiceKey.java
@@ -27,13 +27,17 @@ import java.util.Objects;
  */
 public class ServiceKey implements Service {
 
-    private final String namespace;
+    private String namespace;
 
-    private final String service;
+    private String service;
 
     public ServiceKey(String namespace, String service) {
         this.namespace = namespace;
         this.service = service;
+    }
+
+    public ServiceKey() {
+
     }
 
     @Override
@@ -44,6 +48,14 @@ public class ServiceKey implements Service {
     @Override
     public String getService() {
         return service;
+    }
+
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
+    }
+
+    public void setService(String service) {
+        this.service = service;
     }
 
     @Override

--- a/polaris-common/polaris-model/src/main/java/com/tencent/polaris/api/pojo/SourceService.java
+++ b/polaris-common/polaris-model/src/main/java/com/tencent/polaris/api/pojo/SourceService.java
@@ -17,6 +17,7 @@
 
 package com.tencent.polaris.api.pojo;
 
+import com.tencent.polaris.api.utils.CollectionUtils;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -24,53 +25,51 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import com.tencent.polaris.api.utils.CollectionUtils;
-
 /**
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
 public class SourceService extends ServiceInfo {
 
-	private Set<RouteArgument> arguments = new HashSet<>();
+    private final Set<RouteArgument> arguments = new HashSet<>();
 
-	public Set<RouteArgument> getArguments() {
-		return arguments;
-	}
+    public Set<RouteArgument> getArguments() {
+        return arguments;
+    }
 
-	public void appendArguments(RouteArgument argument) {
-		arguments.add(argument);
-	}
+    public void appendArguments(RouteArgument argument) {
+        arguments.add(argument);
+    }
 
-	public void setArguments(Set<RouteArgument> arguments) {
-		if (!CollectionUtils.isEmpty(arguments)) {
-			this.arguments.addAll(arguments);
-		}
-	}
+    public void setArguments(Set<RouteArgument> arguments) {
+        if (!CollectionUtils.isEmpty(arguments)) {
+            this.arguments.addAll(arguments);
+        }
+    }
 
-	public Map<String, String> getLabels() {
-		if (CollectionUtils.isEmpty(arguments)) {
-			return Optional.ofNullable(super.getMetadata()).orElse(Collections.emptyMap());
-		}
+    public Map<String, String> getLabels() {
+        if (CollectionUtils.isEmpty(arguments)) {
+            return Optional.ofNullable(super.getMetadata()).orElse(Collections.emptyMap());
+        }
 
-		Map<String, String> labels = new HashMap<>();
-		arguments.forEach(entry -> entry.toLabel(labels));
-		return labels;
-	}
+        Map<String, String> labels = new HashMap<>();
+        arguments.forEach(entry -> entry.toLabel(labels));
+        return labels;
+    }
 
-	/**
-	 * use {@link SourceService#setArguments(Set)} to replace {@link SourceService#setMetadata(Map)}
-	 *
-	 * @param metadata
-	 */
-	@Deprecated
-	@Override
-	public void setMetadata(Map<String, String> metadata) {
-		metadata.forEach((key, value) -> appendArguments(RouteArgument.fromLabel(key, value)));
-	}
+    /**
+     * use {@link SourceService#setArguments(Set)} to replace {@link SourceService#setMetadata(Map)}
+     *
+     * @param metadata
+     */
+    @Deprecated
+    @Override
+    public void setMetadata(Map<String, String> metadata) {
+        metadata.forEach((key, value) -> appendArguments(RouteArgument.fromLabel(key, value)));
+    }
 
-	@Deprecated
-	@Override
-	public Map<String, String> getMetadata() {
-		return getLabels();
-	}
+    @Deprecated
+    @Override
+    public Map<String, String> getMetadata() {
+        return getLabels();
+    }
 }

--- a/polaris-discovery/polaris-discovery-api/src/main/java/com/tencent/polaris/api/rpc/GetInstancesRequest.java
+++ b/polaris-discovery/polaris-discovery-api/src/main/java/com/tencent/polaris/api/rpc/GetInstancesRequest.java
@@ -17,15 +17,14 @@
 
 package com.tencent.polaris.api.rpc;
 
+import com.tencent.polaris.api.pojo.RouteArgument;
+import com.tencent.polaris.api.pojo.ServiceInfo;
+import com.tencent.polaris.api.pojo.SourceService;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
-import com.tencent.polaris.api.pojo.RouteArgument;
-import com.tencent.polaris.api.pojo.ServiceInfo;
-import com.tencent.polaris.api.pojo.SourceService;
 
 /**
  * 批量服务实例查询请求
@@ -35,120 +34,123 @@ import com.tencent.polaris.api.pojo.SourceService;
  */
 public class GetInstancesRequest extends RequestBaseEntity {
 
-	/**
-	 * 服务元数据信息，用于服务路由过滤
-	 */
-	private Map<String, String> metadata;
+    /**
+     * 服务元数据信息，用于服务路由过滤
+     */
+    private Map<String, String> metadata;
 
-	/**
-	 * 主调方服务信息
-	 */
-	private SourceService sourceService;
+    /**
+     * 主调方服务信息
+     */
+    private SourceService sourceService;
 
-	/**
-	 * 是否返回熔断实例，默认否
-	 */
-	private boolean includeCircuitBreak;
-	/**
-	 * 是否返回不健康的服务实例，默认否
-	 */
-	private boolean includeUnhealthy;
+    /**
+     * 是否返回熔断实例，默认否
+     */
+    private boolean includeCircuitBreak;
+    /**
+     * 是否返回不健康的服务实例，默认否
+     */
+    private boolean includeUnhealthy;
 
-	/**
-	 * 金丝雀集群
-	 */
-	private String canary;
+ 
+    //各个路由插件依赖的 metadata 参数
+    private Map<String, Set<RouteArgument>> routerArgument;
 
-	/**
-	 * 接口参数
-	 */
-	private String method;
+    /**
+     * 金丝雀集群
+     */
+    private String canary;
 
-	/**
-	 * 可选, metadata失败降级策略
-	 */
-	private MetadataFailoverType metadataFailoverType;
+    /**
+     * 接口参数
+     */
+    private String method;
 
-	public boolean isIncludeCircuitBreak() {
-		return includeCircuitBreak;
-	}
+    /**
+     * 可选, metadata失败降级策略
+     */
+    private MetadataFailoverType metadataFailoverType;
 
-	public void setIncludeCircuitBreak(boolean includeCircuitBreak) {
-		this.includeCircuitBreak = includeCircuitBreak;
-	}
+    public boolean isIncludeCircuitBreak() {
+        return includeCircuitBreak;
+    }
 
-	public Map<String, String> getMetadata() {
-		return metadata;
-	}
+    public void setIncludeCircuitBreak(boolean includeCircuitBreak) {
+        this.includeCircuitBreak = includeCircuitBreak;
+    }
 
-	public void setMetadata(Map<String, String> metadata) {
-		this.metadata = metadata;
-	}
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
 
-	public boolean isIncludeUnhealthy() {
-		return includeUnhealthy;
-	}
+    public void setMetadata(Map<String, String> metadata) {
+        this.metadata = metadata;
+    }
 
-	public void setIncludeUnhealthy(boolean includeUnhealthy) {
-		this.includeUnhealthy = includeUnhealthy;
-	}
+    public boolean isIncludeUnhealthy() {
+        return includeUnhealthy;
+    }
+
+    public void setIncludeUnhealthy(boolean includeUnhealthy) {
+        this.includeUnhealthy = includeUnhealthy;
+    }
 
 
-	public SourceService getServiceInfo() {
-		return sourceService;
-	}
+    public SourceService getServiceInfo() {
+        return sourceService;
+    }
 
-	public void setServiceInfo(ServiceInfo serviceInfo) {
-		if (serviceInfo instanceof SourceService) {
-			this.sourceService = (SourceService) serviceInfo;
-		}
-		else {
-			SourceService sourceService = new SourceService();
-			sourceService.setNamespace(serviceInfo.getNamespace());
-			sourceService.setService(serviceInfo.getService());
-			Set<RouteArgument> argumentSet = new HashSet<>();
-			Optional.ofNullable(serviceInfo.getMetadata()).orElse(Collections.emptyMap())
-					.forEach((key, value) -> argumentSet.add(RouteArgument.fromLabel(key, value)));
-			sourceService.setArguments(argumentSet);
-			this.sourceService = sourceService;
-		}
-	}
+    public void setServiceInfo(ServiceInfo serviceInfo) {
+        if (serviceInfo instanceof SourceService) {
+            this.sourceService = (SourceService) serviceInfo;
+        } else {
+            SourceService sourceService = new SourceService();
+            sourceService.setNamespace(serviceInfo.getNamespace());
+            sourceService.setService(serviceInfo.getService());
+            Set<RouteArgument> argumentSet = new HashSet<>();
+            Optional.ofNullable(serviceInfo.getMetadata()).orElse(Collections.emptyMap())
+                    .forEach((key, value) -> argumentSet.add(RouteArgument.fromLabel(key, value)));
+            sourceService.setArguments(argumentSet);
+            this.sourceService = sourceService;
+        }
+    }
 
-	public String getCanary() {
-		return canary;
-	}
+    public String getCanary() {
+        return canary;
+    }
 
-	public void setCanary(String canary) {
-		this.canary = canary;
-	}
+    public void setCanary(String canary) {
+        this.canary = canary;
+    }
 
-	public String getMethod() {
-		return method;
-	}
+    public String getMethod() {
+        return method;
+    }
 
-	public void setMethod(String method) {
-		this.method = method;
-	}
+    public void setMethod(String method) {
+        this.method = method;
+    }
 
-	public MetadataFailoverType getMetadataFailoverType() {
-		return metadataFailoverType;
-	}
+    public MetadataFailoverType getMetadataFailoverType() {
+        return metadataFailoverType;
+    }
 
-	public void setMetadataFailoverType(MetadataFailoverType metadataFailoverType) {
-		this.metadataFailoverType = metadataFailoverType;
-	}
+    public void setMetadataFailoverType(MetadataFailoverType metadataFailoverType) {
+        this.metadataFailoverType = metadataFailoverType;
+    }
 
-	@Override
-	@SuppressWarnings("checkstyle:all")
-	public String toString() {
-		return "GetInstancesRequest{" +
-				"metadata=" + metadata +
-				", sourceService=" + sourceService +
-				", includeCircuitBreak=" + includeCircuitBreak +
-				", includeUnhealthy=" + includeUnhealthy +
-				", canary='" + canary + '\'' +
-				", method='" + method + '\'' +
-				", metadataFailoverType=" + metadataFailoverType +
-				"} " + super.toString();
-	}
+    @Override
+    @SuppressWarnings("checkstyle:all")
+    public String toString() {
+        return "GetInstancesRequest{" +
+                "metadata=" + metadata +
+                ", sourceService=" + sourceService +
+                ", includeCircuitBreak=" + includeCircuitBreak +
+                ", includeUnhealthy=" + includeUnhealthy +
+                ", canary='" + canary + '\'' +
+                ", method='" + method + '\'' +
+                ", metadataFailoverType=" + metadataFailoverType +
+                "} " + super.toString();
+    }
 }

--- a/polaris-discovery/polaris-discovery-api/src/main/java/com/tencent/polaris/api/rpc/GetOneInstanceRequest.java
+++ b/polaris-discovery/polaris-discovery-api/src/main/java/com/tencent/polaris/api/rpc/GetOneInstanceRequest.java
@@ -19,15 +19,12 @@ package com.tencent.polaris.api.rpc;
 
 import com.tencent.polaris.api.pojo.RouteArgument;
 import com.tencent.polaris.api.pojo.ServiceInfo;
-import com.tencent.polaris.api.pojo.ServiceMetadata;
 import com.tencent.polaris.api.pojo.SourceService;
-
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiConsumer;
 
 /**
  * 单个服务实例查询请求
@@ -61,6 +58,7 @@ public class GetOneInstanceRequest extends RequestBaseEntity {
      * 可选, metadata失败降级策略
      */
     private MetadataFailoverType metadataFailoverType;
+
 
     /**
      * 主调方服务信息

--- a/polaris-discovery/polaris-discovery-client/src/main/java/com/tencent/polaris/discovery/client/flow/CommonInstancesRequest.java
+++ b/polaris-discovery/polaris-discovery-client/src/main/java/com/tencent/polaris/discovery/client/flow/CommonInstancesRequest.java
@@ -101,7 +101,7 @@ public class CommonInstancesRequest implements ServiceEventKeysProvider, FlowCon
         dstServiceInfo.setService(request.getService());
         dstServiceInfo.setMetadata(request.getMetadata());
 
-        routeInfo = new RouteInfo(null, dstServiceInfo, null);
+        routeInfo = new RouteInfo(null, dstServiceInfo, null, configuration.getProvider().getService());
         routeInfo.setIncludeUnhealthyInstances(false);
         Boolean includeCircuitBreak = request.getIncludeCircuitBreakInstances();
         if (null != includeCircuitBreak) {
@@ -147,7 +147,8 @@ public class CommonInstancesRequest implements ServiceEventKeysProvider, FlowCon
         dstServiceInfo.setNamespace(request.getNamespace());
         dstServiceInfo.setService(request.getService());
         dstServiceInfo.setMetadata(request.getMetadata());
-        routeInfo = new RouteInfo(srcServiceInfo, dstServiceInfo, request.getMethod());
+        routeInfo = new RouteInfo(srcServiceInfo, dstServiceInfo, request.getMethod(),
+                configuration.getProvider().getService());
         routeInfo.setCanary(request.getCanary());
         routeInfo.setMetadataFailoverType(request.getMetadataFailoverType());
         criteria = request.getCriteria();
@@ -179,7 +180,8 @@ public class CommonInstancesRequest implements ServiceEventKeysProvider, FlowCon
         dstServiceInfo.setNamespace(request.getNamespace());
         dstServiceInfo.setService(request.getService());
         dstServiceInfo.setMetadata(request.getMetadata());
-        routeInfo = new RouteInfo(srcServiceInfo, dstServiceInfo, request.getMethod());
+        routeInfo = new RouteInfo(srcServiceInfo, dstServiceInfo, request.getMethod(),
+                configuration.getProvider().getService());
         routeInfo.setIncludeCircuitBreakInstances(request.isIncludeCircuitBreak());
         routeInfo.setIncludeUnhealthyInstances(request.isIncludeUnhealthy());
         routeInfo.setCanary(request.getCanary());

--- a/polaris-plugins/polaris-plugins-router/router-rule/src/test/java/com/tencent/polaris/plugins/router/rule/RuleBasedRouterTest.java
+++ b/polaris-plugins/polaris-plugins-router/router-rule/src/test/java/com/tencent/polaris/plugins/router/rule/RuleBasedRouterTest.java
@@ -135,7 +135,7 @@ public class RuleBasedRouterTest {
         v1ReqMeta.put("application", "demo-consumer");
         v1ServiceInfo.setMetadata(v1ReqMeta);
         RouteInfo v1RouteInfo = new RouteInfo(
-                v1ServiceInfo, null, defaultServiceInstances, rule, "bid");
+                v1ServiceInfo, null, defaultServiceInstances, rule, "bid", null);
         Map<String, Set<RouteArgument>> argumentsMap = new HashMap<>();
         argumentsMap.put("ruleRouter", new HashSet<>());
         argumentsMap.get("ruleRouter").add(RouteArgument.buildHeader("req", "v1"));
@@ -170,7 +170,7 @@ public class RuleBasedRouterTest {
         v1ServiceInfo.setMetadata(v1ReqMeta);
         v1ServiceInfo.appendArguments(RouteArgument.buildHeader("req", "v1_copy"));
         RouteInfo v1RouteInfo = new RouteInfo(
-                v1ServiceInfo, null, defaultServiceInstances, rule, "bid");
+                v1ServiceInfo, null, defaultServiceInstances, rule, "bid", null);
         boolean enableV1 = ruleBasedRouter.enable(v1RouteInfo, defaultServiceInstances);
         Assert.assertTrue(enableV1);
         RouteResult result = ruleBasedRouter.router(v1RouteInfo, defaultServiceInstances);
@@ -201,7 +201,7 @@ public class RuleBasedRouterTest {
         v1ServiceInfo.setMetadata(v1ReqMeta);
         v1ServiceInfo.appendArguments(RouteArgument.buildHeader("req", "v1_copy"));
         RouteInfo v1RouteInfo = new RouteInfo(
-                v1ServiceInfo, null, defaultServiceInstances, rule, "bid");
+                v1ServiceInfo, null, defaultServiceInstances, rule, "bid", null);
         boolean enableV1 = ruleBasedRouter.enable(v1RouteInfo, defaultServiceInstances);
         Assert.assertTrue(enableV1);
         RouteResult result = ruleBasedRouter.router(v1RouteInfo, defaultServiceInstances);
@@ -232,7 +232,7 @@ public class RuleBasedRouterTest {
         v1ServiceInfo.setMetadata(v1ReqMeta);
         v1ServiceInfo.appendArguments(RouteArgument.buildHeader("req", "polarissssssmesh"));
         RouteInfo v1RouteInfo = new RouteInfo(
-                v1ServiceInfo, null, defaultServiceInstances, rule, "bid");
+                v1ServiceInfo, null, defaultServiceInstances, rule, "bid", null);
         boolean enableV1 = ruleBasedRouter.enable(v1RouteInfo, defaultServiceInstances);
         Assert.assertTrue(enableV1);
         RouteResult result = ruleBasedRouter.router(v1RouteInfo, defaultServiceInstances);
@@ -263,7 +263,7 @@ public class RuleBasedRouterTest {
         v1ReqMeta.put("req", "v1");
         v1ServiceInfo.setMetadata(v1ReqMeta);
         RouteInfo v1RouteInfo = new RouteInfo(
-                v1ServiceInfo, null, defaultServiceInstances, rule, "bid");
+                v1ServiceInfo, null, defaultServiceInstances, rule, "bid", null);
         boolean enableV1 = ruleBasedRouter.enable(v1RouteInfo, defaultServiceInstances);
         Assert.assertTrue(enableV1);
         RouteResult result = ruleBasedRouter.router(v1RouteInfo, defaultServiceInstances);
@@ -307,7 +307,7 @@ public class RuleBasedRouterTest {
         v1ReqMeta.put("req", "v1");
         v1ServiceInfo.setMetadata(v1ReqMeta);
         RouteInfo v1RouteInfo = new RouteInfo(
-                v1ServiceInfo, null, defaultServiceInstances, rule, null);
+                v1ServiceInfo, null, defaultServiceInstances, rule, null, null);
         boolean enableV1 = ruleBasedRouter.enable(v1RouteInfo, defaultServiceInstances);
         Assert.assertTrue(enableV1);
         for (int i = 0; i < 10; i++) {
@@ -321,7 +321,7 @@ public class RuleBasedRouterTest {
         v2ReqMeta.put("req", "v2");
         v2ServiceInfo.setMetadata(v2ReqMeta);
         RouteInfo v2RouteInfo = new RouteInfo(
-                v2ServiceInfo, null, defaultServiceInstances, rule, null);
+                v2ServiceInfo, null, defaultServiceInstances, rule, null, null);
         boolean enableV2 = ruleBasedRouter.enable(v1RouteInfo, defaultServiceInstances);
         Assert.assertTrue(enableV2);
         for (int i = 0; i < 10; i++) {
@@ -367,7 +367,7 @@ public class RuleBasedRouterTest {
         v1ReqMeta.put("req", "v1");
         v1ServiceInfo.setMetadata(v1ReqMeta);
         RouteInfo v1RouteInfo = new RouteInfo(
-                v1ServiceInfo, null, defaultServiceInstances, rule, null);
+                v1ServiceInfo, null, defaultServiceInstances, rule, null, null);
         boolean enableV1 = ruleBasedRouter.enable(v1RouteInfo, defaultServiceInstances);
         Assert.assertTrue(enableV1);
         for (int i = 0; i < 10; i++) {
@@ -381,7 +381,7 @@ public class RuleBasedRouterTest {
         v2ReqMeta.put("req", "v2");
         v2ServiceInfo.setMetadata(v2ReqMeta);
         RouteInfo v2RouteInfo = new RouteInfo(
-                v2ServiceInfo, null, defaultServiceInstances, rule, null);
+                v2ServiceInfo, null, defaultServiceInstances, rule, null, null);
         boolean enableV2 = ruleBasedRouter.enable(v1RouteInfo, defaultServiceInstances);
         Assert.assertTrue(enableV2);
         for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
* fix: server switch not work when only 1 server in cluster (#264)

* feat：support circuitbreaker by service and interface

* fix import error

* fix: missing import compile error

* feat: 增加predicate的包装类

* feat：支持熔断探测

* fix: matchMetadata parameter confusion

* change version to 1.11.0-SNAPSHOT

* fix: http detect result reverse

* fix: circuitbreaker bugs

* feat：支持通过sourceservice过滤规则

* fix：解决实例级熔断没有传入sourceservice的问题