### PR TITLE
fix: 修改routerInfo构造器后，编译失败问题 (#309)

### DIFF
--- a/polaris-router/polaris-router-client/src/main/java/com/tencent/polaris/router/client/api/DefaultRouterAPI.java
+++ b/polaris-router/polaris-router-client/src/main/java/com/tencent/polaris/router/client/api/DefaultRouterAPI.java
@@ -47,11 +47,9 @@ import com.tencent.polaris.router.api.rpc.ProcessRoutersRequest;
 import com.tencent.polaris.router.api.rpc.ProcessRoutersRequest.RouterNamesGroup;
 import com.tencent.polaris.router.api.rpc.ProcessRoutersResponse;
 import com.tencent.polaris.router.client.util.RouterValidator;
-
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
 import org.slf4j.Logger;
 
 /**
@@ -106,7 +104,8 @@ public class DefaultRouterAPI extends BaseEngine implements RouterAPI {
         SourceService sourceService = new SourceService();
         sourceService.setService(request.getSourceService().getService());
         sourceService.setNamespace(request.getSourceService().getNamespace());
-        RouteInfo routeInfo = new RouteInfo(sourceService, dstInstances, request.getMethod());
+        RouteInfo routeInfo = new RouteInfo(sourceService, dstInstances, request.getMethod(),
+                config.getProvider().getService());
         routeInfo.setRouterArguments(request.getRouterArguments());
         if (request.getMetadataFailoverType() != null) {
             routeInfo.setMetadataFailoverType(request.getMetadataFailoverType());


### PR DESCRIPTION
* fix: server switch not work when only 1 server in cluster (#264)

* feat：support circuitbreaker by service and interface

* fix import error

* fix: missing import compile error

* feat: 增加predicate的包装类

* feat：支持熔断探测

* fix: matchMetadata parameter confusion

* change version to 1.11.0-SNAPSHOT

* fix: http detect result reverse

* fix: circuitbreaker bugs

* feat：支持通过sourceservice过滤规则

* fix：解决实例级熔断没有传入sourceservice的问题

* fix: 编译失败问题